### PR TITLE
Draft: Threads views tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.models import User
+
+from django_ai_assistant.models import Message, Thread
+
+
+def create_thread(
+    name: str | None = None, user: User | None = None, message: str | None = None
+) -> Thread:
+    name = name or "Test Thread"
+    user = user or User.objects.create_user(username="test_user")
+    message = message or "Test Message"
+
+    thread = Thread.objects.create(name=name, created_by=user)
+
+    Message.objects.create(message={"content": message}, thread=thread)
+
+    thread.refresh_from_db()
+
+    return thread

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 
+from django.contrib.auth.models import User
 from django.test import Client, TestCase
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from django_ai_assistant.exceptions import AIAssistantNotDefinedError
 from django_ai_assistant.helpers.assistants import AIAssistant, register_assistant
 from django_ai_assistant.tools import BaseModel, Field, method_tool
+from tests.helpers import create_thread
 
 
 # Set up
@@ -73,4 +75,24 @@ class AssistantViewsTests(TestCase):
 
 # Threads Views
 
-# Up next
+
+class ThreadsListViewsTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.client = Client()
+        self.client.login(username="testuser", password="password")
+
+    def test_list_threads_without_results(self):
+        response = self.client.get("/threads/")
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json() == []
+
+    def test_list_threads_with_results(self):
+        thread = create_thread(user=self.user)
+
+        response = self.client.get("/threads/")
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()[0].get("id") == thread.id


### PR DESCRIPTION
Folks, I created this draft to get your opinion on something. For test data, we have a few options:

1. Use a lib like factory or baker - I'm not a huge fan of this option as this lib's models are fairly simple, so I don't think we gain a lot by adding this extra dependency.
2. Create objects within the test file - I think this one is simple, but can become a little messy.
3. Create a helper service within the test file - Could work, but I also find it a little messy.
4. Create a helper service in `helpers.py` (within the tests folder) - **That's what I went with**, but I also saw there's an `utils.py` file. I figured the purposes were a little different, but I can add the helper to utils if it makes sense.

Anyway, let me know what you think. This is not a blocker, I'm working on other tests in the meantime, but I'd like to get your opinion before opening the definitive PR.