### PR TITLE
Fix refs error when pushing to gh-pages branch

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: gh-pages
+          fetch-depth: 0
 
       - name: checkout current branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Fix error raised on https://github.com/vintasoftware/django-ai-assistant/actions/runs/9703380899/job/26781375619 based on https://github.com/jimporter/mike/issues/28#issuecomment-730813808
