### PR TITLE
Upgrade HTMX example to HTMX 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ db.sqlite3-journal
 /mediafiles/*
 __pycache__/
 /.vscode/
+/.mypy_cache/
 
 # coverage result
 .coverage

--- a/example/demo/templates/demo/chat_home.html
+++ b/example/demo/templates/demo/chat_home.html
@@ -28,8 +28,8 @@
               class="btn btn-primary mt-3"
               hx-post='{% url "chat_home" %}'
               hx-target="#threads-container"
-              hx-select="#messages-container"
-              hx-select-oob="#messages-container"
+              hx-select="#messages-list"
+              hx-select-oob="#messages-list"
               hx-push-url="true"
               data-loading-disable
             >

--- a/example/demo/templates/demo/htmx_index.html
+++ b/example/demo/templates/demo/htmx_index.html
@@ -16,9 +16,8 @@
     />
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/5.3.3/js/bootstrap.min.js"></script>
     <!-- HTMX -->
-    <script src="https://unpkg.com/htmx.org@1.5.0/dist/htmx.min.js"></script>
-    <script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js"></script>
-    <script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/loading-states.js"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.0/dist/htmx.min.js"></script>
+    <script src="https://unpkg.com/htmx-ext-loading-states@2.0.0/loading-states.js"></script>
   </head>
 
   <body


### PR DESCRIPTION
## Issues

Resolves #111 

## Description 

Upgrade HTMX example to HTMX 2.0


## Steps to test

- Make sure the HTMX example is working properly, with no broken behavior.

[Screencast from 01-07-2024 12:00:58.webm](https://github.com/vintasoftware/django-ai-assistant/assets/22326737/bf561d60-2fea-4280-972a-2905db89eea1)

