### PR TITLE
Fix: Make thread_id parameter of AIAssistant run method optional

### DIFF
--- a/django_ai_assistant/helpers/assistants.py
+++ b/django_ai_assistant/helpers/assistants.py
@@ -12,7 +12,10 @@ from langchain.chains.combine_documents.base import (
     DEFAULT_DOCUMENT_PROMPT,
     DEFAULT_DOCUMENT_SEPARATOR,
 )
-from langchain_core.chat_history import BaseChatMessageHistory, InMemoryChatMessageHistory
+from langchain_core.chat_history import (
+    BaseChatMessageHistory,
+    InMemoryChatMessageHistory,
+)
 from langchain_core.language_models import BaseChatModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import (
@@ -295,7 +298,9 @@ class AIAssistant(abc.ABC):  # noqa: F821
         """
 
         # DjangoChatMessageHistory must be here because Django may not be loaded yet elsewhere:
-        from django_ai_assistant.langchain.chat_message_histories import DjangoChatMessageHistory
+        from django_ai_assistant.langchain.chat_message_histories import (
+            DjangoChatMessageHistory,
+        )
 
         if thread_id is None:
             return InMemoryChatMessageHistory()
@@ -538,7 +543,7 @@ class AIAssistant(abc.ABC):  # noqa: F821
         return chain.invoke(*args, **kwargs)
 
     @with_cast_id
-    def run(self, message: str, thread_id: Any | None, **kwargs: Any) -> str:
+    def run(self, message: str, thread_id: Any | None = None, **kwargs: Any) -> str:
         """Run the assistant with the given message and thread ID.\n
         This is the higher-level method to run the assistant.\n
 

--- a/tests/test_helpers/test_assistants.py
+++ b/tests/test_helpers/test_assistants.py
@@ -1,4 +1,5 @@
 from typing import List
+from unittest.mock import patch
 
 import pytest
 from langchain_core.documents import Document
@@ -125,6 +126,18 @@ def test_AIAssistant_invoke():
     )
 
 
+@pytest.mark.django_db(transaction=True)
+def test_AIAssistant_run_handles_optional_thread_id_param():
+    assistant = AIAssistant.get_cls("temperature_assistant")()
+
+    with patch.object(assistant, "invoke") as invoke_spy:
+        assistant.run("What is the temperature today in Recife?")
+
+        invoke_spy.assert_called_once_with(
+            {"input": "What is the temperature today in Recife?"}, thread_id=None
+        )
+
+
 class SequentialRetriever(BaseRetriever):
     sequential_responses: List[List[Document]]
     response_index: int = 0
@@ -222,4 +235,9 @@ def test_AIAssistant_tool_order_same_as_declaration():
     assistant = FooAssistant()
 
     assert hasattr(assistant, "_method_tools")
-    assert [t.name for t in assistant._method_tools] == ["tool_d", "tool_c", "tool_b", "tool_a"]
+    assert [t.name for t in assistant._method_tools] == [
+        "tool_d",
+        "tool_c",
+        "tool_b",
+        "tool_a",
+    ]

--- a/tests/test_helpers/test_assistants.py
+++ b/tests/test_helpers/test_assistants.py
@@ -126,7 +126,6 @@ def test_AIAssistant_invoke():
     )
 
 
-@pytest.mark.django_db(transaction=True)
 def test_AIAssistant_run_handles_optional_thread_id_param():
     assistant = AIAssistant.get_cls("temperature_assistant")()
 


### PR DESCRIPTION
The following command in the ["Manually calling an AI Assistant"](https://vintasoftware.github.io/django-ai-assistant/latest/tutorial/#manually-calling-an-ai-assistant) section of the Tutorial is failing:

```python
In [2]: assistant = WeatherAIAssistant()
   ...: output = assistant.run("What's the weather in New York City?")

TypeError: AIAssistant.run() missing 1 required positional argument: 'thread_id'
```

This PR is to provide a default value for the `thread_id` parameter, to make the example work again.

It's also including a regression test, but let me know if that's overkill, I can remove it.

