### PR TITLE
Allow omitting `temperature` in `get_llm` for models that do not support it

### DIFF
--- a/django_ai_assistant/helpers/assistants.py
+++ b/django_ai_assistant/helpers/assistants.py
@@ -250,8 +250,8 @@ class AIAssistant(abc.ABC):  # noqa: F821
         Returning `None` is a valid option, particularly for models that do not support
         temperature control, allowing the parameter to be omitted in the `get_llm` method.\n
 
-            Returns:
-                float | None: The temperature to use for the assistant LLM model.
+        Returns:
+            float | None: The temperature to use for the assistant LLM model.
         """
         return self.temperature
 

--- a/tests/test_helpers/test_assistants.py
+++ b/tests/test_helpers/test_assistants.py
@@ -289,24 +289,25 @@ def test_AIAssistant_get_llm_default_temperature(mock_chat_openai):
 
     mock_chat_openai.assert_called_once_with(
         model="gpt-test",
-        temperature=assistant.temperature,
+        temperature=1.0,
         model_kwargs={},
     )
+
     AIAssistant.clear_cls_registry()
 
 
 @patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
-def test_AIAssistant_get_llm_custom_temperature(mock_chat_openai):
+def test_AIAssistant_get_llm_custom_float_temperature(mock_chat_openai):
     custom_temperature = 0.5
 
-    class CustomTempAssistant(AIAssistant):
-        id = "custom_temp_assistant"  # noqa: A003
-        name = "Custom Temp Assistant"
+    class CustomFloatTempAssistant(AIAssistant):
+        id = "custom_float_temp_assistant"  # noqa: A003
+        name = "Custom Float Temp Assistant"
         instructions = "Instructions"
         model = "gpt-test"
         temperature = custom_temperature
 
-    assistant = CustomTempAssistant()
+    assistant = CustomFloatTempAssistant()
     assistant.get_llm()
 
     mock_chat_openai.assert_called_once_with(
@@ -314,23 +315,24 @@ def test_AIAssistant_get_llm_custom_temperature(mock_chat_openai):
         temperature=custom_temperature,
         model_kwargs={},
     )
+
     AIAssistant.clear_cls_registry()
 
 
 @patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
-def test_AIAssistant_get_llm_override_get_temperature(mock_chat_openai):
+def test_AIAssistant_get_llm_override_get_temperature_with_float(mock_chat_openai):
     custom_temperature = 0.5
 
-    class OverrideGetTempAssistant(AIAssistant):
-        id = "override_temp_assistant"  # noqa: A003
-        name = "Override Temp Assistant"
+    class OverrideGetFloatTempAssistant(AIAssistant):
+        id = "override_get_float_temp_assistant"  # noqa: A003
+        name = "Override Get Float Temp Assistant"
         instructions = "Instructions"
         model = "gpt-test"
 
         def get_temperature(self) -> float | None:
             return custom_temperature
 
-    assistant = OverrideGetTempAssistant()
+    assistant = OverrideGetFloatTempAssistant()
     assistant.get_llm()
 
     mock_chat_openai.assert_called_once_with(
@@ -338,21 +340,20 @@ def test_AIAssistant_get_llm_override_get_temperature(mock_chat_openai):
         temperature=custom_temperature,
         model_kwargs={},
     )
+
     AIAssistant.clear_cls_registry()
 
 
 @patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
-def test_AIAssistant_get_llm_none_temperature(mock_chat_openai):
-    class NoneTempAssistant(AIAssistant):
-        id = "none_temp_assistant"  # noqa: A003
-        name = "None Temp Assistant"
+def test_AIAssistant_get_llm_custom_none_temperature(mock_chat_openai):
+    class CustomNoneTempAssistant(AIAssistant):
+        id = "custom_none_temp_assistant"  # noqa: A003
+        name = "Custom None Temp Assistant"
         instructions = "Instructions"
         model = "gpt-test"
+        temperature = None
 
-        def get_temperature(self) -> float | None:
-            return None
-
-    assistant = NoneTempAssistant()
+    assistant = CustomNoneTempAssistant()
     assistant.get_llm()
 
     mock_chat_openai.assert_called_once_with(
@@ -362,7 +363,31 @@ def test_AIAssistant_get_llm_none_temperature(mock_chat_openai):
     _, call_kwargs = mock_chat_openai.call_args
     assert "temperature" not in call_kwargs
 
-    AIAssistant.clear_cls_registry()  # Clean up registry
+    AIAssistant.clear_cls_registry()
+
+
+@patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
+def test_AIAssistant_get_llm_override_get_temperature_with_none(mock_chat_openai):
+    class OverrideGetNoneTempAssistant(AIAssistant):
+        id = "override_get_none_temp_assistant"  # noqa: A003
+        name = "Override Get None Temp Assistant"
+        instructions = "Instructions"
+        model = "gpt-test"
+
+        def get_temperature(self) -> float | None:
+            return None
+
+    assistant = OverrideGetNoneTempAssistant()
+    assistant.get_llm()
+
+    mock_chat_openai.assert_called_once_with(
+        model="gpt-test",
+        model_kwargs={},
+    )
+    _, call_kwargs = mock_chat_openai.call_args
+    assert "temperature" not in call_kwargs
+
+    AIAssistant.clear_cls_registry()
 
 
 @pytest.mark.vcr

--- a/tests/test_helpers/test_assistants.py
+++ b/tests/test_helpers/test_assistants.py
@@ -121,7 +121,10 @@ def test_AIAssistant_invoke():
                 id="4",
             ),
             HumanMessage(
-                content="What about tomorrow?", additional_kwargs={}, response_metadata={}, id="5"
+                content="What about tomorrow?",
+                additional_kwargs={},
+                response_metadata={},
+                id="5",
             ),
             AIMessage(
                 content="",
@@ -271,6 +274,95 @@ def test_AIAssistant_tool_order_same_as_declaration():
         "tool_b",
         "tool_a",
     ]
+
+
+@patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
+def test_AIAssistant_get_llm_default_temperature(mock_chat_openai):
+    class DefaultTempAssistant(AIAssistant):
+        id = "default_temp_assistant"  # noqa: A003
+        name = "Default Temp Assistant"
+        instructions = "Instructions"
+        model = "gpt-test"
+
+    assistant = DefaultTempAssistant()
+    assistant.get_llm()
+
+    mock_chat_openai.assert_called_once_with(
+        model="gpt-test",
+        temperature=assistant.temperature,
+        model_kwargs={},
+    )
+    AIAssistant.clear_cls_registry()
+
+
+@patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
+def test_AIAssistant_get_llm_custom_temperature(mock_chat_openai):
+    custom_temperature = 0.5
+
+    class CustomTempAssistant(AIAssistant):
+        id = "custom_temp_assistant"  # noqa: A003
+        name = "Custom Temp Assistant"
+        instructions = "Instructions"
+        model = "gpt-test"
+        temperature = custom_temperature
+
+    assistant = CustomTempAssistant()
+    assistant.get_llm()
+
+    mock_chat_openai.assert_called_once_with(
+        model="gpt-test",
+        temperature=custom_temperature,
+        model_kwargs={},
+    )
+    AIAssistant.clear_cls_registry()
+
+
+@patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
+def test_AIAssistant_get_llm_override_get_temperature(mock_chat_openai):
+    custom_temperature = 0.5
+
+    class OverrideGetTempAssistant(AIAssistant):
+        id = "override_temp_assistant"  # noqa: A003
+        name = "Override Temp Assistant"
+        instructions = "Instructions"
+        model = "gpt-test"
+
+        def get_temperature(self) -> float | None:
+            return custom_temperature
+
+    assistant = OverrideGetTempAssistant()
+    assistant.get_llm()
+
+    mock_chat_openai.assert_called_once_with(
+        model="gpt-test",
+        temperature=custom_temperature,
+        model_kwargs={},
+    )
+    AIAssistant.clear_cls_registry()
+
+
+@patch("django_ai_assistant.helpers.assistants.ChatOpenAI")
+def test_AIAssistant_get_llm_none_temperature(mock_chat_openai):
+    class NoneTempAssistant(AIAssistant):
+        id = "none_temp_assistant"  # noqa: A003
+        name = "None Temp Assistant"
+        instructions = "Instructions"
+        model = "gpt-test"
+
+        def get_temperature(self) -> float | None:
+            return None
+
+    assistant = NoneTempAssistant()
+    assistant.get_llm()
+
+    mock_chat_openai.assert_called_once_with(
+        model="gpt-test",
+        model_kwargs={},
+    )
+    _, call_kwargs = mock_chat_openai.call_args
+    assert "temperature" not in call_kwargs
+
+    AIAssistant.clear_cls_registry()  # Clean up registry
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
## Description

- Resolves #193 

#### Related resources

- https://community.openai.com/t/o3-mini-unsupported-parameter-temperature/1140846

## Steps to test

- [ ] Assess whether the regression tests are passing
- [ ] Assess whether the docs are up-to-date
  ```bash
  poetry mkdocs build
  poetry mkdocs serve
  ```

[Screencast from 09-04-2025 18:38:35.webm](https://github.com/user-attachments/assets/c5efd603-fc3e-41a7-abd3-6556bf51adee)

## Summary by Sourcery

Modify the AI assistant implementation to support optional temperature parameter for LLM models

Bug Fixes:
- Resolve issue with temperature parameter for models that do not support temperature control

Enhancements:
- Allow omitting temperature parameter when set to None for LLM models that do not support temperature control

Tests:
- Add comprehensive test cases to verify temperature handling in get_llm method
- Test scenarios for default, custom, overridden, and None temperature values