### PR TITLE
Fixing python versions in tox execution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,18 +26,19 @@ basepython =
     py312: python3.12
     py313: python3.13
 deps =
-    poetry
+    coverage
+    model-bakery
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-django
+    pytest-recording
+    python-dotenv
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
 passenv =
     OPENAI_API_KEY
-commands_pre =
-    poetry install --with dev
-    django42: pip install --force-reinstall --no-deps 'Django>=4.2,<4.3'
-    django50: pip install --force-reinstall --no-deps 'Django>=5.0,<5.1'
-    django51: pip install --force-reinstall --no-deps 'Django>=5.1,<5.2'
-    django52: pip install --force-reinstall --no-deps 'Django>=5.2,<5.3'
 commands =
-    poetry run pytest --cov=django_ai_assistant {posargs}
+    pytest --cov=django_ai_assistant {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,9 @@ passenv =
     OPENAI_API_KEY
 commands_pre =
     poetry install --with dev
+    django42: pip install --force-reinstall --no-deps 'Django>=4.2,<4.3'
+    django50: pip install --force-reinstall --no-deps 'Django>=5.0,<5.1'
+    django51: pip install --force-reinstall --no-deps 'Django>=5.1,<5.2'
+    django52: pip install --force-reinstall --no-deps 'Django>=5.2,<5.3'
 commands =
     poetry run pytest --cov=django_ai_assistant {posargs}


### PR DESCRIPTION
The tox configuration is running all tests against the most recent version of Django.

### The issue
`poetry install --with dev` in tox's `commands_pre` would overwrite whatever Django version tox installed, upgrading everything to the latest version (5.2) because `pyproject.toml` specifies `Django = ">=4.2"`.

### Evidence
In the logs, you can see environment `py310-django42` (which should test Django 4.2) actually running with `django: version: 5.2`. 
<img width="579" height="387" alt="1759319568669" src="https://github.com/user-attachments/assets/c69428ad-0f76-4a43-b5cd-d582dbf4b21c" />


### The Fix
Added force-reinstall commands in tox.ini after poetry install to ensure each environment uses its designated Django version.

### Result
Now we're actually testing all Django/Python combinations. Here are the logs from the most recent build:
<img width="745" height="501" alt="1759319612578" src="https://github.com/user-attachments/assets/7ced20ff-a487-4cee-8236-5280a225e069" />