### PR TITLE
Conditionally bulk_insert Messages

### DIFF
--- a/django_ai_assistant/helpers/django_messages.py
+++ b/django_ai_assistant/helpers/django_messages.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from django.db import transaction
+from django.db import connections, transaction
 
 from langchain_core.messages import (
     BaseMessage,
@@ -35,9 +35,18 @@ def save_django_messages(messages: list[BaseMessage], thread: "Thread") -> list[
 
     messages_to_create = [m for m in messages if m.id not in existing_message_ids]
 
-    created_messages = DjangoMessage.objects.bulk_create(
-        [DjangoMessage(thread=thread, message={}) for _ in messages_to_create]
-    )
+    # Insert in bulk only if primary keys are then assigned by the DB.
+    if connections[
+        DjangoMessage.objects.db
+    ].features.can_return_rows_from_bulk_insert:
+        created_messages = DjangoMessage.objects.bulk_create(
+            [DjangoMessage(thread=thread, message={}) for _ in messages_to_create],
+        )
+    else:
+        for message in (created_messages := [
+            DjangoMessage(thread=thread, message={}) for _ in messages_to_create
+        ]):
+            message.save()
 
     # Update langchain message IDs with Django message IDs
     for idx, created_message in enumerate(created_messages):


### PR DESCRIPTION
Compatibility with e.g. Mysql, where bulk insert does not return generated primary keys.

## Summary by Sourcery

Support databases without bulk insert row-returning capability by falling back to individual saves for message creation.

Bug Fixes:
- Ensure compatibility with DBs (e.g. MySQL) that don’t return generated primary keys from bulk insert.

Enhancements:
- Conditionally use bulk_create when the DB can return inserted rows and otherwise save messages individually to assign IDs correctly.