### PR TITLE
fix: resolve unhandled 500 errors, UUID casting edge cases, and Pydantic deprecation warnings

### DIFF
--- a/django_ai_assistant/api/schemas.py
+++ b/django_ai_assistant/api/schemas.py
@@ -4,7 +4,6 @@ from django.utils import timezone
 
 from ninja import Field, ModelSchema, Schema
 
-# from django_ai_assistant.models import Thread
 from django_ai_assistant.models import Thread as ThreadModel
 
 

--- a/django_ai_assistant/api/schemas.py
+++ b/django_ai_assistant/api/schemas.py
@@ -15,7 +15,6 @@ class Assistant(Schema):
 
 class Thread(ModelSchema):
     class Meta:
-        # model = Thread
         model = ThreadModel
         fields = (
             "id",

--- a/django_ai_assistant/api/schemas.py
+++ b/django_ai_assistant/api/schemas.py
@@ -4,7 +4,9 @@ from django.utils import timezone
 
 from ninja import Field, ModelSchema, Schema
 
-from django_ai_assistant.models import Thread
+# from django_ai_assistant.models import Thread
+from django_ai_assistant.models import Thread as ThreadModel
+
 
 
 class Assistant(Schema):
@@ -14,7 +16,8 @@ class Assistant(Schema):
 
 class Thread(ModelSchema):
     class Meta:
-        model = Thread
+        # model = Thread
+        model = ThreadModel
         fields = (
             "id",
             "name",

--- a/django_ai_assistant/api/views.py
+++ b/django_ai_assistant/api/views.py
@@ -17,11 +17,12 @@ from django_ai_assistant.api.schemas import (
     ThreadMessageIn,
 )
 from django_ai_assistant.conf import app_settings
-from django_ai_assistant.decorators import with_cast_id
+from django_ai_assistant.decorators import (with_cast_id, InvalidObjectIdError)
 from django_ai_assistant.exceptions import AIAssistantNotDefinedError, AIUserNotAllowedError
 from django_ai_assistant.helpers import use_cases
 from django_ai_assistant.models import Message as MessageModel
 from django_ai_assistant.models import Thread as ThreadModel
+
 
 
 class API(NinjaAPI):
@@ -160,3 +161,12 @@ def delete_thread_message(request, thread_id: Any, message_id: Any):
         request=request,
     )
     return 204, None
+
+
+@api.exception_handler(InvalidObjectIdError)
+def invalid_object_id_handler(request, exc):
+    return api.create_response(
+        request,
+        {"message": str(exc)},
+        status=404,
+    )

--- a/django_ai_assistant/api/views.py
+++ b/django_ai_assistant/api/views.py
@@ -136,7 +136,8 @@ def list_thread_messages(request, thread_id: Any):
 )
 @with_cast_id
 def create_thread_message(request, thread_id: Any, payload: ThreadMessageIn):
-    thread = ThreadModel.objects.get(id=thread_id)
+    # thread = ThreadModel.objects.get(id=thread_id)
+    thread = get_object_or_404(ThreadModel, id=thread_id)
 
     use_cases.create_message(
         assistant_id=payload.assistant_id,

--- a/django_ai_assistant/api/views.py
+++ b/django_ai_assistant/api/views.py
@@ -136,7 +136,6 @@ def list_thread_messages(request, thread_id: Any):
 )
 @with_cast_id
 def create_thread_message(request, thread_id: Any, payload: ThreadMessageIn):
-    # thread = ThreadModel.objects.get(id=thread_id)
     thread = get_object_or_404(ThreadModel, id=thread_id)
 
     use_cases.create_message(

--- a/django_ai_assistant/apps.py
+++ b/django_ai_assistant/apps.py
@@ -15,12 +15,12 @@ class AIAssistantConfig(AppConfig):
         for app in apps.get_app_configs():
             try:
                 import_module(f"{app.name}.ai_assistants")
-            except ModuleNotFoundError:
+            except ModuleNotFoundError as err:
                 # If the module exists but there is an error in it, we want to raise the error:
                 try:
                     # This raises on single-module app, e.g. django-health-check v4.0+:
                     # health_check.contrib.celery.
                     if importlib.util.find_spec(f"{app.name}.ai_assistants"):
-                        raise
+                        raise err
                 except ModuleNotFoundError:
                     pass

--- a/django_ai_assistant/apps.py
+++ b/django_ai_assistant/apps.py
@@ -15,12 +15,17 @@ class AIAssistantConfig(AppConfig):
         for app in apps.get_app_configs():
             try:
                 import_module(f"{app.name}.ai_assistants")
-            except ModuleNotFoundError as err:
-                # If the module exists but there is an error in it, we want to raise the error:
+            except ModuleNotFoundError:
+                # Only ignore the case where <app>.ai_assistants itself does not exist.
+                # If the module exists but fails because of an internal missing dependency,
+                # surface the original exception.
                 try:
-                    # This raises on single-module app, e.g. django-health-check v4.0+:
-                    # health_check.contrib.celery.
-                    if importlib.util.find_spec(f"{app.name}.ai_assistants"):
-                        raise err
+                    module_exists = (
+                        importlib.util.find_spec(f"{app.name}.ai_assistants")
+                        is not None
+                    )
                 except ModuleNotFoundError:
-                    pass
+                    module_exists = False
+
+                if module_exists:
+                    raise

--- a/django_ai_assistant/decorators.py
+++ b/django_ai_assistant/decorators.py
@@ -1,6 +1,5 @@
 import uuid
 from functools import wraps
-from django.http import Http404
 
 
 def _cast_id(item_id, model):

--- a/django_ai_assistant/decorators.py
+++ b/django_ai_assistant/decorators.py
@@ -1,10 +1,20 @@
 import uuid
 from functools import wraps
+from django.http import Http404
+
+
+# def _cast_id(item_id, model):
+#     if isinstance(item_id, str) and "UUID" in model._meta.pk.get_internal_type():
+#         return uuid.UUID(item_id)
+#     return item_id
 
 
 def _cast_id(item_id, model):
     if isinstance(item_id, str) and "UUID" in model._meta.pk.get_internal_type():
-        return uuid.UUID(item_id)
+        try:
+            return uuid.UUID(item_id)
+        except ValueError:
+            raise Http404("Invalid ID format")
     return item_id
 
 

--- a/django_ai_assistant/decorators.py
+++ b/django_ai_assistant/decorators.py
@@ -3,18 +3,12 @@ from functools import wraps
 from django.http import Http404
 
 
-# def _cast_id(item_id, model):
-#     if isinstance(item_id, str) and "UUID" in model._meta.pk.get_internal_type():
-#         return uuid.UUID(item_id)
-#     return item_id
-
-
 def _cast_id(item_id, model):
     if isinstance(item_id, str) and "UUID" in model._meta.pk.get_internal_type():
         try:
             return uuid.UUID(item_id)
         except ValueError:
-            raise Http404("Invalid ID format")
+            raise ValueError("Invalid UUID format")
     return item_id
 
 

--- a/django_ai_assistant/decorators.py
+++ b/django_ai_assistant/decorators.py
@@ -2,12 +2,16 @@ import uuid
 from functools import wraps
 
 
+class InvalidObjectIdError(ValueError):
+    """Raised when an object ID cannot be converted to the expected type."""
+
+
 def _cast_id(item_id, model):
     if isinstance(item_id, str) and "UUID" in model._meta.pk.get_internal_type():
         try:
             return uuid.UUID(item_id)
-        except ValueError:
-            raise ValueError("Invalid UUID format")
+        except ValueError as exc:
+            raise InvalidObjectIdError("Invalid UUID format") from exc
     return item_id
 
 

--- a/django_ai_assistant/helpers/assistants.py
+++ b/django_ai_assistant/helpers/assistants.py
@@ -242,11 +242,13 @@ class AIAssistant(abc.ABC):  # noqa: F821
         # Remove self from each tool args_schema:
         for tool in tools:
             if tool.args_schema:
-                if isinstance(tool.args_schema.__fields_set__, set):
-                    tool.args_schema.__fields_set__.remove("self")
-                tool.args_schema.__fields__.pop("self", None)
+                if hasattr(tool.args_schema, "model_fields"):
+                    tool.args_schema.model_fields.pop("self", None)
+                else:
+                    tool.args_schema.__fields__.pop("self", None)
 
         self._method_tools = tools
+        
 
     @classmethod
     def get_cls_registry(cls) -> dict[str, type["AIAssistant"]]:

--- a/django_ai_assistant/helpers/assistants.py
+++ b/django_ai_assistant/helpers/assistants.py
@@ -53,6 +53,22 @@ from django_ai_assistant.helpers.django_messages import save_django_messages
 from django_ai_assistant.langchain.tools import tool as tool_decorator
 
 
+def remove_schema_field(schema_cls: type[Any], field_name: str) -> None:
+    """Remove a field from a Pydantic schema class.
+
+    Handles both Pydantic v2 (model_fields) and Pydantic v1 (__fields__).
+    """
+    if hasattr(schema_cls, "model_fields"):  # Pydantic v2
+        schema_cls.model_fields.pop(field_name, None)
+        return
+
+    if hasattr(schema_cls, "__fields__"):  # Pydantic v1
+        schema_cls.__fields__.pop(field_name, None)
+        return
+
+    raise TypeError(f"Unsupported schema class: {schema_cls!r}")
+
+
 ProviderName = Literal["openai", "anthropic", "google"]
 
 
@@ -242,10 +258,7 @@ class AIAssistant(abc.ABC):  # noqa: F821
         # Remove self from each tool args_schema:
         for tool in tools:
             if tool.args_schema:
-                if hasattr(tool.args_schema, "model_fields"):
-                    tool.args_schema.model_fields.pop("self", None)
-                else:
-                    tool.args_schema.__fields__.pop("self", None)
+                remove_schema_field(tool.args_schema, "self")
 
         self._method_tools = tools
         

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -398,3 +398,13 @@ def test_delete_thread_message(authenticated_client):
 
     assert response.status_code == HTTPStatus.NO_CONTENT
     assert not Message.objects.filter(id=message.id).exists()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_list_thread_messages_returns_404_for_invalid_uuid(authenticated_client, monkeypatch):
+    monkeypatch.setattr(Thread._meta.pk, "get_internal_type", lambda: "UUIDField")
+    response = authenticated_client.get(
+        reverse("django_ai_assistant:messages_list_create", kwargs={"thread_id": "not-a-uuid"})
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert response.json() == {"message": "Invalid UUID format"}


### PR DESCRIPTION
Fix the api endpoints to gracefully handle invalid data inputs, resolve namespace conflicts, and align with Pydantic V2 standards. In [views.py](https://github.com/user-attachments/files/29653936/views.py) direct database lookups using **.get()** within **create_thread_message** are replaced with **get_object_or_404** to prevent unhandled 500 server crashes when a non-existent thread ID is supplied. Similarly, the ID-casting engine in `decorators.py` now wraps **uuid.UUID** conversions in a **try/except ValueError** block to correctly return an **Http404** instead of a crash when a malformed UUID string passes through path parameters. In [schemas.py](https://github.com/user-attachments/files/29653941/schemas.py), the imported **Thread** Django model is aliased to **ThreadModel** to safeguard against namespace shadowing conflicts with the Pydantic **Thread** schema class. Additionally, the application autodiscovery sequence in [apps.py](https://github.com/user-attachments/files/29653946/apps.py) is refined to explicitly re-raise captured **ModuleNotFoundError** scopes when identifying broken nested sub-module definitions. Finally, the **PydanticDeprecatedSince20** warnings emitted across the test suite are eliminated by swapping out the deprecated **__fields__** attribute for **model_fields** inside the [assistants.py](https://github.com/user-attachments/files/29653955/assistants.py) helper module.
 
 Here is output of Tests
 
<img width="1484" height="486" alt="image" src="https://github.com/user-attachments/assets/55c8b863-52a9-43a9-94e7-bed4531f3909" />
